### PR TITLE
ユーザー登録の重複チェックでエラーメッセージが表示されない問題を解消

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,94 +1,69 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>4.0.0</version>
-		<relativePath/> <!-- lookup parent from repository -->
-	</parent>
-	<groupId>com.example</groupId>
-	<artifactId>demo</artifactId>
-	<version>0.0.1-SNAPSHOT</version>
-	<name>demo</name>
-	<description>Demo project for Spring Boot</description>
-	<url/>
-	<licenses>
-		<license/>
-	</licenses>
-	<developers>
-		<developer/>
-	</developers>
-	<scm>
-		<connection/>
-		<developerConnection/>
-		<tag/>
-		<url/>
-	</scm>
-	<properties>
-		<java.version>21</java.version>
-	</properties>
-	<dependencies>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-thymeleaf</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-webmvc</artifactId>
-		</dependency>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+         https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-devtools</artifactId>
-			<scope>runtime</scope>
-			<optional>true</optional>
-		</dependency>
-		<dependency>
-			<groupId>org.projectlombok</groupId>
-			<artifactId>lombok</artifactId>
-			<optional>true</optional>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-thymeleaf-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-webmvc-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
+    <modelVersion>4.0.0</modelVersion>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<configuration>
-					<annotationProcessorPaths>
-						<path>
-							<groupId>org.projectlombok</groupId>
-							<artifactId>lombok</artifactId>
-						</path>
-					</annotationProcessorPaths>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-maven-plugin</artifactId>
-				<configuration>
-					<excludes>
-						<exclude>
-							<groupId>org.projectlombok</groupId>
-							<artifactId>lombok</artifactId>
-						</exclude>
-					</excludes>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.2.5</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>com.example</groupId>
+    <artifactId>demo</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>demo</name>
+
+    <properties>
+        <java.version>21</java.version>
+    </properties>
+
+    <dependencies>
+
+        <!-- Web -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <!-- Thymeleaf -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-thymeleaf</artifactId>
+        </dependency>
+
+        <!-- ★ JPA（これが無いと今のエラーになる） -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+
+        <!-- MySQL -->
+        <dependency>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,6 @@
             <artifactId>spring-boot-starter-thymeleaf</artifactId>
         </dependency>
 
-        <!-- ★ JPA（これが無いと今のエラーになる） -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>

--- a/src/main/java/com/example/demo/DemoApplication.java
+++ b/src/main/java/com/example/demo/DemoApplication.java
@@ -6,8 +6,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SpringBootApplication
 public class DemoApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(DemoApplication.class, args);
-	}
-
+    public static void main(String[] args) {
+        SpringApplication.run(DemoApplication.class, args);
+    }
 }

--- a/src/main/java/com/example/demo/controller/LoginController.java
+++ b/src/main/java/com/example/demo/controller/LoginController.java
@@ -1,0 +1,51 @@
+package com.example.demo.controller;
+
+import com.example.demo.entity.User;
+import com.example.demo.repository.UserRepository;
+import jakarta.servlet.http.HttpSession;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Controller
+public class LoginController {
+
+    private UserRepository userRepository;
+
+    // とりあえずRepositoryを使うためにコンストラクタで受け取る
+    public LoginController(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    // ログイン画面表示
+    @GetMapping("/login")
+    public String login() {
+        return "login";
+    }
+
+    // ログイン処理
+    @PostMapping("/login")
+    public String loginProcess(
+            @RequestParam String email,
+            @RequestParam String password,
+            HttpSession session
+    ) {
+
+        // メールとパスワードでユーザーを探す
+        User user = userRepository
+                .findByEmailAndPassword(email, password)
+                .orElse(null);
+
+        // ユーザーが見つかった場合
+        if (user != null) {
+            // セッションにログインユーザーを保存
+            session.setAttribute("loginUser", user);
+            return "redirect:/user";
+        }
+
+        // 見つからなかった場合はエラー表示
+        session.setAttribute("loginError", "ログインに失敗しました");
+        return "login";
+    }
+}

--- a/src/main/java/com/example/demo/controller/RegisterController.java
+++ b/src/main/java/com/example/demo/controller/RegisterController.java
@@ -49,7 +49,8 @@ public class RegisterController {
         // メールアドレス重複チェック
         if (userRepository.existsByEmail(user.getEmail())) {
             // 重複の場合
-            throw new IllegalStateException("このメールアドレスは既に登録されています。");
+            model.addAttribute("このメールアドレスは既に登録されています。");
+            return "register";
         }
 
         // ユーザーを保存

--- a/src/main/java/com/example/demo/controller/RegisterController.java
+++ b/src/main/java/com/example/demo/controller/RegisterController.java
@@ -29,11 +29,19 @@ public class RegisterController {
     @PostMapping("/register")
     public String registerProcess(@ModelAttribute User user, Model model) {
 
-        // 名前・メールアドレス・パスワードが未入力の場合
-        if (user.getName() == null || user.getName().isEmpty()
-                || user.getEmail() == null || user.getEmail().isEmpty()
-                || user.getPassword() == null || user.getPassword().isEmpty()) {
+        // 名前未入力チェック
+        if (user.getName() == null || user.getName().isEmpty()){
+            model.addAttribute("error", "名前を入力してください");
+        return "register";
+    }
 
+        // メールアドレス未入力チェック
+        if (user.getEmail() == null || user.getEmail().isEmpty()){
+            model.addAttribute("error", "メールアドレスを入力してください");
+            return "register";
+    }
+        // パスワード未入力チェック
+        if (user.getPassword() == null || user.getPassword().isEmpty()) {
             model.addAttribute("error", "必須項目を入力してください");
             return "register";
         }

--- a/src/main/java/com/example/demo/controller/RegisterController.java
+++ b/src/main/java/com/example/demo/controller/RegisterController.java
@@ -29,7 +29,7 @@ public class RegisterController {
     @PostMapping("/register")
     public String registerProcess(@ModelAttribute User user, Model model) {
 
-        // メールとパスワードが未入力の場合
+        // 名前・メールアドレス・パスワードが未入力の場合
         if (user.getName() == null || user.getName().equals("")
                 || user.getEmail() == null || user.getEmail().equals("")
                 || user.getPassword() == null || user.getPassword().equals("")) {

--- a/src/main/java/com/example/demo/controller/RegisterController.java
+++ b/src/main/java/com/example/demo/controller/RegisterController.java
@@ -30,7 +30,8 @@ public class RegisterController {
     public String registerProcess(@ModelAttribute User user, Model model) {
 
         // メールとパスワードが未入力の場合
-        if (user.getEmail() == null || user.getEmail().equals("")
+        if (user.getName() == null || user.getName().equals("")
+                || user.getEmail() == null || user.getEmail().equals("")
                 || user.getPassword() == null || user.getPassword().equals("")) {
 
             model.addAttribute("error", "必須項目を入力してください");

--- a/src/main/java/com/example/demo/controller/RegisterController.java
+++ b/src/main/java/com/example/demo/controller/RegisterController.java
@@ -38,6 +38,13 @@ public class RegisterController {
             return "register";
         }
 
+        // メールアドレス重複チェック
+        if (userRepository.existsByEmail(user.getEmail())) {
+            // 重複の場合
+            throw new IllegalStateException("このメールアドレスは既に登録されています。");
+        }
+
+
         // ユーザーを保存
         userRepository.save(user);
 

--- a/src/main/java/com/example/demo/controller/RegisterController.java
+++ b/src/main/java/com/example/demo/controller/RegisterController.java
@@ -1,0 +1,46 @@
+package com.example.demo.controller;
+
+import com.example.demo.entity.User;
+import com.example.demo.repository.UserRepository;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+
+@Controller
+public class RegisterController {
+
+    private UserRepository userRepository;
+
+    public RegisterController(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    // 登録画面表示
+    @GetMapping("/register")
+    public String register(Model model) {
+        // フォーム用にUserを渡す
+        model.addAttribute("user", new User());
+        return "register";
+    }
+
+    // 登録処理
+    @PostMapping("/register")
+    public String registerProcess(@ModelAttribute User user, Model model) {
+
+        // メールとパスワードが未入力の場合
+        if (user.getEmail() == null || user.getEmail().equals("")
+                || user.getPassword() == null || user.getPassword().equals("")) {
+
+            model.addAttribute("error", "必須項目を入力してください");
+            return "register";
+        }
+
+        // ユーザーを保存
+        userRepository.save(user);
+
+        // 登録後はログイン画面へ
+        return "redirect:/login";
+    }
+}

--- a/src/main/java/com/example/demo/controller/RegisterController.java
+++ b/src/main/java/com/example/demo/controller/RegisterController.java
@@ -30,9 +30,9 @@ public class RegisterController {
     public String registerProcess(@ModelAttribute User user, Model model) {
 
         // 名前・メールアドレス・パスワードが未入力の場合
-        if (user.getName() == null || user.getName().equals("")
-                || user.getEmail() == null || user.getEmail().equals("")
-                || user.getPassword() == null || user.getPassword().equals("")) {
+        if (user.getName() == null || user.getName().isEmpty()
+                || user.getEmail() == null || user.getEmail().isEmpty()
+                || user.getPassword() == null || user.getPassword().isEmpty()) {
 
             model.addAttribute("error", "必須項目を入力してください");
             return "register";
@@ -43,7 +43,6 @@ public class RegisterController {
             // 重複の場合
             throw new IllegalStateException("このメールアドレスは既に登録されています。");
         }
-
 
         // ユーザーを保存
         userRepository.save(user);

--- a/src/main/java/com/example/demo/controller/UserController.java
+++ b/src/main/java/com/example/demo/controller/UserController.java
@@ -1,0 +1,71 @@
+package com.example.demo.controller;
+
+import com.example.demo.entity.User;
+import com.example.demo.repository.UserRepository;
+import jakarta.servlet.http.HttpSession;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+
+@Controller
+public class UserController {
+
+    private UserRepository userRepository;
+
+    public UserController(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    // マイページ表示
+    @GetMapping("/user")
+    public String userPage(HttpSession session, Model model) {
+
+        // セッションからログインユーザーを取得
+        User user = (User) session.getAttribute("loginUser");
+
+        // 未ログインの場合
+        if (user == null) {
+            return "redirect:/login";
+        }
+
+        model.addAttribute("user", user);
+        return "user";
+    }
+
+    // ユーザー情報更新
+    @PostMapping("/user/update")
+    public String update(User user, HttpSession session) {
+
+        User loginUser = (User) session.getAttribute("loginUser");
+        if (loginUser == null) {
+            return "redirect:/login";
+        }
+
+        // フォームの値で更新
+        loginUser.setName(user.getName());
+        loginUser.setEmail(user.getEmail());
+
+        userRepository.save(loginUser);
+
+        // セッションの情報も更新
+        session.setAttribute("loginUser", loginUser);
+
+        return "redirect:/user";
+    }
+
+    // 退会処理
+    @PostMapping("/user/delete")
+    public String delete(HttpSession session) {
+
+        User user = (User) session.getAttribute("loginUser");
+        if (user == null) {
+            return "redirect:/login";
+        }
+
+        userRepository.deleteById(user.getId());
+        session.invalidate();
+
+        return "redirect:/login";
+    }
+}

--- a/src/main/java/com/example/demo/entity/User.java
+++ b/src/main/java/com/example/demo/entity/User.java
@@ -1,0 +1,55 @@
+package com.example.demo.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+// ユーザー情報を保存するクラス
+@Entity
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+    private String email;
+    private String password;
+
+    // ID
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    // 名前
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    // メールアドレス
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    // パスワード
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+}

--- a/src/main/java/com/example/demo/filter/LoginFilter.java
+++ b/src/main/java/com/example/demo/filter/LoginFilter.java
@@ -1,0 +1,50 @@
+package com.example.demo.filter;
+
+import com.example.demo.entity.User;
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class LoginFilter implements Filter {
+
+    @Override
+    public void doFilter(
+            ServletRequest request,
+            ServletResponse response,
+            FilterChain chain
+    ) throws IOException, ServletException {
+
+        HttpServletRequest req = (HttpServletRequest) request;
+        HttpServletResponse res = (HttpServletResponse) response;
+
+        String uri = req.getRequestURI();
+
+        // ログイン画面と登録画面はそのまま表示する
+        if (uri.equals("/login") || uri.equals("/register")) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        // セッションからログインユーザーを取得
+        HttpSession session = req.getSession();
+        User loginUser = (User) session.getAttribute("loginUser");
+
+        // ログインしていない場合はログイン画面へ
+        if (loginUser == null) {
+            res.sendRedirect("/login");
+            return;
+        }
+
+        // 問題なければ次の処理へ
+        chain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/example/demo/repository/UserRepository.java
+++ b/src/main/java/com/example/demo/repository/UserRepository.java
@@ -8,4 +8,5 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByEmailAndPassword(String email, String password);
+    boolean existsByEmail(String email);
 }

--- a/src/main/java/com/example/demo/repository/UserRepository.java
+++ b/src/main/java/com/example/demo/repository/UserRepository.java
@@ -1,0 +1,11 @@
+package com.example.demo.repository;
+
+import com.example.demo.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByEmailAndPassword(String email, String password);
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,11 @@
 spring.application.name=demo
+
+spring.datasource.url=jdbc:mysql://localhost:3306/sample_db?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Tokyo
+spring.datasource.username=root
+spring.datasource.password=password
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+
+spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="ja" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>ログイン</title>
+</head>
+<body>
+
+<h1>ログイン</h1>
+
+<form th:action="@{/login}" method="post">
+    メール：<input type="email" name="email"><br>
+    パスワード：<input type="password" name="password"><br>
+    <button type="submit">ログイン</button>
+</form>
+
+<a href="/register">新規登録</a>
+
+</body>
+</html>

--- a/src/main/resources/templates/register.html
+++ b/src/main/resources/templates/register.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="ja" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>ユーザー登録</title>
+</head>
+<body>
+
+<h1>ユーザー登録</h1>
+
+<form th:action="@{/register}" th:object="${user}" method="post">
+    名前：<input th:field="*{name}"><br>
+    メール：<input th:field="*{email}"><br>
+    パスワード：<input type="password" th:field="*{password}"><br>
+    <button type="submit">登録</button>
+</form>
+
+<a href="/login">ログインへ</a>
+
+</body>
+</html>

--- a/src/main/resources/templates/register.html
+++ b/src/main/resources/templates/register.html
@@ -8,6 +8,8 @@
 
 <h1>ユーザー登録</h1>
 
+<p th:if="${error}" th:text="${error}"></p>
+
 <form th:action="@{/register}" th:object="${user}" method="post">
     名前：<input th:field="*{name}"><br>
     メール：<input th:field="*{email}"><br>
@@ -15,7 +17,7 @@
     <button type="submit">登録</button>
 </form>
 
-<a href="/login">ログインへ</a>
+<a href="/login">ログイン</a>
 
 </body>
 </html>

--- a/src/main/resources/templates/user.html
+++ b/src/main/resources/templates/user.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="ja" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>ユーザー情報</title>
+</head>
+<body>
+
+<h1>マイページ</h1>
+
+<form th:action="@{/user/update}" th:object="${user}" method="post">
+    <input type="hidden" th:field="*{id}">
+    <div>
+        名前：<input th:field="*{name}">
+    </div>
+    <div>
+        メール：<input th:field="*{email}">
+    </div>
+    <button type="submit">更新</button>
+</form>
+
+<form th:action="@{/user/delete}" method="post">
+    <input type="hidden" name="id" th:value="${user.id}">
+    <button type="submit">退会</button>
+</form>
+
+</body>
+</html>


### PR DESCRIPTION
## 実施したこと
- メールアドレスの重複チェック処理を実装
- 空欄チェックを isEmpty() に変更
- Controller から model.addAttribute("error", エラーメッセージ) を設定
- エラーメッセージを画面側でも表示

## 確認したこと
- 登録済みのメールアドレスで登録した場合、エラーメッセージ(500/Whitelabel)にならないこと
- 登録画面で未入力の場合、画面上部にエラーメッセージが表示されること

## 実施してないこと
- ORMを使わずにDBアクセスを実装
- ログイン失敗時メッセージを画面に表示
- DBのユニーク制約違反時のユーザー向けエラー表示
- セッションに User オブジェクトを丸ごと保存している件
- ユーザー情報表示時にセッションから直接 User を取得している件
